### PR TITLE
Expect more generic versions  in integration tests

### DIFF
--- a/integration/env_var_test.go
+++ b/integration/env_var_test.go
@@ -65,7 +65,7 @@ func testRunWithEnvVar(t *testing.T, context spec.G, it spec.S) {
 					settings.Buildpacks.Bundler.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
-				WithEnv(map[string]string{"BP_BUNDLER_VERSION": "2.1.*"}).
+				WithEnv(map[string]string{"BP_BUNDLER_VERSION": "2.*"}).
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)
 
@@ -87,20 +87,20 @@ func testRunWithEnvVar(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(string(content)).To(ContainSubstring(fmt.Sprintf("/layers/%s/bundler/bin/bundler", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))))
-			Expect(string(content)).To(MatchRegexp(`Bundler version 2\.1\.\d+`))
+			Expect(string(content)).To(MatchRegexp(`Bundler version 2\.\d+\.\d+`))
 
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Resolving Bundler version",
 				"    Candidate version sources (in priority order):",
-				"      BP_BUNDLER_VERSION -> \"2.1.*\"",
+				"      BP_BUNDLER_VERSION -> \"2.*\"",
 				"      buildpack.yml      -> \"1.17.x\"",
 				"      <unknown>          -> \"*\"",
 				"",
-				MatchRegexp(`    Selected Bundler version \(using BP_BUNDLER_VERSION\): 2\.1\.\d+`),
+				MatchRegexp(`    Selected Bundler version \(using BP_BUNDLER_VERSION\): 2\.\d+\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Bundler 2\.1\.\d+`),
+				MatchRegexp(`    Installing Bundler 2\.\d+\.\d+`),
 				MatchRegexp(`      Completed in \d+\.?\d*`),
 				"",
 				"  Configuring environment",

--- a/integration/gemfile_lock_test.go
+++ b/integration/gemfile_lock_test.go
@@ -92,7 +92,7 @@ func testGemfileLock(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Resolving Bundler version",
 				"    Candidate version sources (in priority order):",
-				"      Gemfile.lock -> \"1.17.3\"",
+				MatchRegexp(`      Gemfile.lock -> \"1\.17\.\d+\"`),
 				"      <unknown>    -> \"*\"",
 				"",
 				MatchRegexp(`    Selected Bundler version \(using Gemfile\.lock\): 1\.17\.\d+`),

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -201,10 +201,10 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Resolving Bundler version",
 				"    Candidate version sources (in priority order):",
-				"      Gemfile.lock -> \"1.17.3\"",
+				MatchRegexp(`    Gemfile.lock -> \"1\.17\.\d+\"`),
 				"      <unknown>    -> \"*\"",
 				"",
-				"    Selected Bundler version (using Gemfile.lock): 1.17.3",
+				MatchRegexp(`    Selected Bundler version \(using Gemfile\.lock\): 1\.17\.\d+`),
 				"",
 				"  Executing build process",
 				MatchRegexp(`    Installing Bundler 1\.17\.\d+`),
@@ -230,7 +230,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			re := regexp.MustCompile(`BUNDLED WITH\s+\d+\.\d+\.\d+`)
-			err = ioutil.WriteFile(filepath.Join(source, "Gemfile.lock"), re.ReplaceAll(contents, []byte("BUNDLED WITH\n   2.1.4")), 0644)
+			err = ioutil.WriteFile(filepath.Join(source, "Gemfile.lock"), re.ReplaceAll(contents, []byte("BUNDLED WITH\n   2.*")), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Second pack build
@@ -247,13 +247,13 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Resolving Bundler version",
 				"    Candidate version sources (in priority order):",
-				"      Gemfile.lock -> \"2.1.4\"",
+				"      Gemfile.lock -> \"2.*\"",
 				"      <unknown>    -> \"*\"",
 				"",
-				"    Selected Bundler version (using Gemfile.lock): 2.1.4",
+				MatchRegexp(`    Selected Bundler version \(using Gemfile\.lock\): 2\.\d+\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing Bundler 2\.1\.\d+`),
+				MatchRegexp(`    Installing Bundler 2\.\d+\.\d+`),
 				MatchRegexp(`      Completed in \d+\.?\d*`),
 				"",
 				"  Configuring environment",
@@ -281,7 +281,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(string(content)).To(ContainSubstring(fmt.Sprintf("/layers/%s/bundler/bin/bundler", strings.ReplaceAll(settings.Buildpack.ID, "/", "_"))))
-			Expect(string(content)).To(MatchRegexp(`Bundler version 2\.1\.\d+`))
+			Expect(string(content)).To(MatchRegexp(`Bundler version 2\.\d+\.\d+`))
 
 			Expect(secondImage.Buildpacks[1].Layers["bundler"].Metadata["built_at"]).NotTo(Equal(firstImage.Buildpacks[1].Layers["bundler"].Metadata["built_at"]))
 		})


### PR DESCRIPTION

Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:

Uses more generic version expectations in integration tests. 

* An explanation of the use cases your change enables:

This will stop us from having to update test expectations everytime a version is bumped in buildpack.toml.

Please confirm the following:
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
