### PR TITLE
Loosens bundler version requirement to matching major

### DIFF
--- a/gemfile_lock_parser.go
+++ b/gemfile_lock_parser.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/Masterminds/semver"
 )
 
 type GemfileLockParser struct{}
@@ -27,7 +29,12 @@ func (p GemfileLockParser) ParseVersion(path string) (string, error) {
 	for scanner.Scan() {
 		if strings.TrimSpace(scanner.Text()) == "BUNDLED WITH" {
 			if scanner.Scan() {
-				return strings.TrimSpace(scanner.Text()), nil
+				version, err := semver.NewVersion(strings.TrimSpace(scanner.Text()))
+				if err != nil {
+					return "", fmt.Errorf("failed to parse Gemfile.lock: %w", err)
+				}
+
+				return fmt.Sprintf("%d.*.*", version.Major()), nil
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/paketo-buildpacks/bundler
 
 require (
 	github.com/BurntSushi/toml v0.3.1
+	github.com/Masterminds/semver v1.5.0
 	github.com/onsi/gomega v1.10.4
 	github.com/paketo-buildpacks/occam v0.0.23
 	github.com/paketo-buildpacks/packit v0.6.0
@@ -10,4 +11,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-go 1.13
+go 1.15

--- a/integration/gemfile_lock_test.go
+++ b/integration/gemfile_lock_test.go
@@ -92,7 +92,7 @@ func testGemfileLock(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Resolving Bundler version",
 				"    Candidate version sources (in priority order):",
-				MatchRegexp(`      Gemfile.lock -> \"1\.17\.\d+\"`),
+				"      Gemfile.lock -> \"1.*.*\"",
 				"      <unknown>    -> \"*\"",
 				"",
 				MatchRegexp(`    Selected Bundler version \(using Gemfile\.lock\): 1\.17\.\d+`),

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -201,7 +201,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Resolving Bundler version",
 				"    Candidate version sources (in priority order):",
-				MatchRegexp(`    Gemfile.lock -> \"1\.17\.\d+\"`),
+				"      Gemfile.lock -> \"1.*.*\"",
 				"      <unknown>    -> \"*\"",
 				"",
 				MatchRegexp(`    Selected Bundler version \(using Gemfile\.lock\): 1\.17\.\d+`),
@@ -230,7 +230,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			re := regexp.MustCompile(`BUNDLED WITH\s+\d+\.\d+\.\d+`)
-			err = ioutil.WriteFile(filepath.Join(source, "Gemfile.lock"), re.ReplaceAll(contents, []byte("BUNDLED WITH\n   2.*")), 0644)
+			err = ioutil.WriteFile(filepath.Join(source, "Gemfile.lock"), re.ReplaceAll(contents, []byte("BUNDLED WITH\n   2.1.4")), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Second pack build
@@ -247,7 +247,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, settings.Buildpack.Name)),
 				"  Resolving Bundler version",
 				"    Candidate version sources (in priority order):",
-				"      Gemfile.lock -> \"2.*\"",
+				"      Gemfile.lock -> \"2.*.*\"",
 				"      <unknown>    -> \"*\"",
 				"",
 				MatchRegexp(`    Selected Bundler version \(using Gemfile\.lock\): 2\.\d+\.\d+`),

--- a/integration/testdata/gemfile_lock_version/Gemfile.lock
+++ b/integration/testdata/gemfile_lock_version/Gemfile.lock
@@ -11,4 +11,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.3
+   1.15.2


### PR DESCRIPTION
## Summary
Bundler only enforces that version used to `bundle install` match the major version specified in the `Gemfile.lock`. We now parse the version specified in the `Gemfile.lock` and request any version of bundler that matches that major version.

## Use cases
Having an exact match with the bundler version is a burdensome requirement on buildpack users and can be loosened without losing behavior.

Resolves https://github.com/paketo-buildpacks/bundler/issues/141

Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
