### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bundler Cloud Native Buildpack
+# Paketo Buildpack for Bundler
 
 ## `gcr.io/paketo-buildpacks/bundler`
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -5,7 +5,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/bundler"
   id = "paketo-buildpacks/bundler"
   keywords = ["ruby", "bundler"]
-  name = "Paketo Bundler Buildpack"
+  name = "Paketo Buildpack for Bundler"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Bundler Buildpack' to 'Paketo Buildpack for Bundler'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
